### PR TITLE
add support for multiple persistant terminal buffers at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ editableterm.setup({
             }
         },
     },
+    wait_for_keys_delay = 50, -- amount of miliseconds to wait for shell to process keys 
 })
 ```
 #### Default keybinds


### PR DESCRIPTION
If I understood correctly what currently happens is:
You open terminal A: editable-term group is created, autocommands are added for buffer A.
You open terminal B: editable-term group is cleared and recreated, removing A's autocommands.

So I thought scoping the autocmds on pattern term://* and also allowing the same autocmds being used by different term:// buffers we can allow having multiple term buffers which can be used as persistant terms.