### PR TITLE
fix prompt cursor when using clear inside a terminal

### DIFF
--- a/lua/editable-term/init.lua
+++ b/lua/editable-term/init.lua
@@ -174,11 +174,9 @@ M.setup = function(config)
                         for pattern, promt in pairs(M.promts) do
                             start, ent = ln:find(pattern)
                             if start ~= nil then
-                                if ((bufinfo.promt_cursor or {})[1] or 0) < line_num then
-                                    bufinfo.promt_cursor = { line_num, ent }
-                                    bufinfo.keybinds = promt.keybinds or M.default_keybinds
-                                    break
-                                end
+                                bufinfo.promt_cursor = { line_num, ent }
+                                bufinfo.keybinds = promt.keybinds or M.default_keybinds
+                                break
                             end
                         end
                     end


### PR DESCRIPTION
Currently:
Prompt cursor only gets updated when it comes later than previous prompt position.
Sideeffect of this includes having wrong prompt position when calling clear inside a terminal.

Reproduce:
1. Create a terminal and add lines to it.
2. Call clear.
3. Try to use edit command but realize its not modifiable since prompt position did not get reupdated.

Personally haven’t seen any breaking of functionality of resetting prompt cursor every time.
